### PR TITLE
Fix USO_UNSAFE_METHOD_SYNCHRONIZATION SpotBugs warning in WebhookCredentialsProvider

### DIFF
--- a/src/main/java/io/jenkins/plugins/webhookexternalstore/WebhookCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/webhookexternalstore/WebhookCredentialsProvider.java
@@ -46,12 +46,19 @@ public class WebhookCredentialsProvider extends CredentialsProvider {
      */
     private WebhookCredentialsStore store;
 
+    /**
+     * Lock guarding lazy initialization of {@link #store}.
+     */
+    private final Object storeLock = new Object();
+
     @Override
-    public synchronized CredentialsStore getStore(ModelObject object) {
-        if (store == null) {
-            store = new WebhookCredentialsStore(this, Jenkins.get());
+    public CredentialsStore getStore(ModelObject object) {
+        synchronized (storeLock) {
+            if (store == null) {
+                store = new WebhookCredentialsStore(this, Jenkins.get());
+            }
+            return store;
         }
-        return store;
     }
 
     private CredentialsStore getStore() {


### PR DESCRIPTION
### Description

The BOM bump in #28 pulls in a newer SpotBugs version whose new `USO_UNSAFE_METHOD_SYNCHRONIZATION` detector flags `WebhookCredentialsProvider.getStore(ModelObject)`:

> Method uses intrinsic lock of class WebhookCredentialsProvider for synchronization, that is exposed by static getInstance()

Since the provider instance is exposed via the static `getInstance()` accessor, external code could lock on the same monitor as the `synchronized` method. This change synchronizes on a private lock object instead, keeping the lazy initialization of the store thread-safe without exposing the lock.

Verified locally with `mvn compile spotbugs:check`.

### Testing done

- `mvn compile spotbugs:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)